### PR TITLE
Update resource target for VirtualMFADevice permissions

### DIFF
--- a/selfmanagedcredswithmfa_policy.tf
+++ b/selfmanagedcredswithmfa_policy.tf
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "self_managed_creds_with_mfa" {
     ]
 
     resources = [
-      "arn:aws:iam::*:mfa/&{aws:username}",
+      "arn:aws:iam::*:mfa/*",
     ]
   }
 

--- a/selfmanagedcredswithoutmfa_policy.tf
+++ b/selfmanagedcredswithoutmfa_policy.tf
@@ -120,7 +120,7 @@ data "aws_iam_policy_document" "self_managed_creds_without_mfa" {
     ]
 
     resources = [
-      "arn:aws:iam::*:mfa/&{aws:username}",
+      "arn:aws:iam::*:mfa/*",
     ]
   }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR modifies the resource target for `iam:CreateVirtualMFADevice` and `iam:DeleteVirtualMFADevice` permissions in our `self_managed_creds_with_mfa` and `self_managed_creds_without_mfa` policies.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

AWS has changed the way the MFA resources are named behind the scenes, so this update reflects that.  This change is taken directly from [AWS' updated example policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html).  Note that these changes mirror those done in https://github.com/cisagov/cool-accounts/pull/131.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied this change in the Production CyHy account and verified that the policy looks as I expected it would.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

